### PR TITLE
use sbt's recommended publication approach

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: scala
+jdk:
+- openjdk6
+scala:
+- 2.10.4
+before_script:
+- ./bintray.sh
+after_success:
+- sbt publish
+env:
+  global:
+    # to generate this (when in the correct branch of the correct repo):
+    # travis encrypt BINTRAY_TOKEN=<YOUR PRIVATE API KEY> --add
+    secure: EJtrMVOVD5ajjAcmjRh0CrO/v+REjcNvCX+R9kdrNm31NDcuuMCMORjRmC30s0nWeaErLZKoqmIoVfKMI33yF4aloDsgtsxEgXgSHXAQFca9/tlzb+42glEdqMeq4erBL1MgxpvcxJa0Qig24L5+YMpHxRLORwoSJWlmqmO3Suw=

--- a/bintray.sh
+++ b/bintray.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# workaround for https://github.com/softprops/bintray-sbt/issues/25
+
+mkdir -p ${HOME}/.bintray
+echo "realm = Bintray API Realm" > ${HOME}/.bintray/.credentials
+echo "host = api.bintray.com"  >> ${HOME}/.bintray/.credentials
+echo "user = fommil" >> ${HOME}/.bintray/.credentials
+echo "password = ${BINTRAY_TOKEN}"  >> ${HOME}/.bintray/.credentials

--- a/build.sbt
+++ b/build.sbt
@@ -1,56 +1,23 @@
+import bintray.Keys._
+import com.typesafe.sbt.SbtGit._
+
+versionWithGit
+
+git.baseVersion := "0.1.4"
+
 sbtPlugin := true
 
 name := "ensime-sbt"
 
 organization := "org.ensime"
 
-version := "0.1.4-SNAPSHOT"
+publishMavenStyle := false
 
-//pgpSecretRing := file("/Users/aemon/.gnupg/secring.gpg")
+bintrayPublishSettings
 
-crossScalaVersions := Seq("2.10.4")
+bintrayOrganization in bintray := Some("ensime")
 
-scalacOptions := Seq("-deprecation", "-unchecked")
+repository in bintray := "sbt-plugins"
 
-publishTo <<= version { (v: String) =>
-  val nexus = "https://oss.sonatype.org/"
-  if (v.trim.endsWith("SNAPSHOT"))
-    Some("snapshots" at nexus + "content/repositories/snapshots")
-  else
-    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
-}
+licenses += ("BSD", url("http://opensource.org/licenses/BSD-3-Clause"))
 
-credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
-
-publishArtifact in (Compile, packageBin) := true
-
-publishArtifact in (Test, packageBin) := false
-
-publishArtifact in (Compile, packageDoc) := true
-
-publishArtifact in (Compile, packageSrc) := true
-
-publishMavenStyle := true
-
-pomIncludeRepository := { _ => false }
-
-pomExtra := (
-  <url>http://github.com/ensime/ensime-sbt</url>
-  <licenses>
-    <license>
-      <name>BSD-style</name>
-      <url>http://www.opensource.org/licenses/bsd-license.php</url>
-      <distribution>http://github.com/ensime/ensime-sbt</distribution>
-    </license>
-  </licenses>
-  <scm>
-    <url>git@github.com:ensime/ensime-sbt.git</url>
-    <connection>scm:git:git@github.com:ensime/ensime-sbt.git</connection>
-  </scm>
-  <developers>
-    <developer>
-      <id>aemoncannon</id>
-      <name>Aemon Cannon</name>
-      <url>http://github.com/aemoncannon</url>
-    </developer>
-  </developers>)

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,0 +1,6 @@
+resolvers += Resolver.url(
+    "bintray-sbt-plugin-releases",
+     url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
+         Resolver.ivyStylePatterns)
+
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4")


### PR DESCRIPTION
@aemoncannon please follow the signup process here for bintray: create the `sbt-plugins` repo, publish this (add a git tag `v0.1.4` first), and then add that artefact to the sbt plugin distros.

http://www.scala-sbt.org/0.13.5/docs/Community/Bintray-For-Plugins.html

then this PR will allow really simple dists of the sbt plugin without the sonatype staging faff.
