### PR TITLE
Temporarily remove Java sources zip file

### DIFF
--- a/src/main/scala/org/ensime/sbt/EnsimeCommand.scala
+++ b/src/main/scala/org/ensime/sbt/EnsimeCommand.scala
@@ -173,7 +173,8 @@ the configuration."""
     val body = SExp(KeyMap(
         key(":name") -> optSetting(name).map(SExp.apply).getOrElse(NilAtom()),
         key(":scala-version") -> optSetting(scalaVersion).map(SExp.apply).getOrElse(NilAtom()),
-        key(":reference-source-roots") -> SExpList(SExp(javaSrc)),
+      // See issue #518. Restore this line with that issue is resolved.
+      // key(":reference-source-roots") -> SExpList(SExp(javaSrc)),
         key(":subprojects") -> SExp(projs.map{p => SExp(p)})
       )).toPPReadableString
     val header =


### PR DESCRIPTION
See #518. Mixing Java and Scala source jars causes problems with the PresentationCompiler. For the time being don't include the Java src.zip file. Scala reference source browsing continues to work fine.
