### PR TITLE
Migrate ensime to AutoPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
 # ENSIME SBT
 
-This [sbt](http://github.com/sbt/sbt) plugin generates a `.ensime`
-file for use with an
-[ENSIME server](http://github.com/ensime/ensime-server).
+This [sbt](http://github.com/sbt/sbt) plugin generates a `.ensime` file for use with an [ENSIME server](http://github.com/ensime/ensime-server).
 
 The ENSIME ecosystem is actively developed and always looking for new
 contributors. This is a fairly small and easy to understand plugin, so
 please consider sending us a Pull Request if you have any feature
 request ideas.
-
 
 ## Installation
 
@@ -16,6 +13,7 @@ ENSIME is effectively using a rolling release strategy until version
 1.0. The latest plugin is available by adding the following
 to your `~/.sbt/0.13/plugins/plugins.sbt`:
 
+Ensime is now an [AutoPlugin](http://www.scala-sbt.org/release/docs/Plugins.html#Creating+an+auto+plugin), which requires SBT 0.13.5+.
 
 ```scala
 resolvers += Resolver.sonatypeRepo("snapshots")
@@ -31,28 +29,30 @@ If you want to customise the output, create a file `project/ensime.sbt`
 which is ignored by SCM (or use `~/.sbt/0.13/ensime.sbt`), and customise
 like so:
 
+```scala
+import org.ensime.Imports._
+
+EnsimeKeys.compilerArgs in Compile := (scalacOptions in Compile).value ++ Seq("-Ywarn-dead-code", "-Ywarn-shadowing")
+
+// custom settings (this is an example of adding scalariform formatting preferences):
+EnsimeKeys.additionalSExp in Compile := """
+:formatting-prefs (
+  :alignSingleLineCaseStatements nil
+  :multilineScaladocCommentsStartOnFirstLine t
+  :placeScaladocAsterisksBeneathSecondAsterisk t
+)
+"""
 ```
-import EnsimePlugin._
-import EnsimeKeys._
-
-(compilerArgs in Compile) := (scalacOptions in Compile).value ++ Seq("-Ywarn-dead-code", "-Ywarn-shadowing")
-
-(additionalSExp in Compile) := ":custom-key custom-value"
-```
-
-
-Only sbt 0.13.x is supported.
 
 An older 0.1.1 release is available for sbt 0.12, but we don't
 recommend it.
 
-
-## Using
+## Usage
 
 Type `sbt gen-ensime` or, from the sbt prompt:
 
-```
-gen-ensime
+```bash
+> gen-ensime
 ```
 
 Downloading and resolving the sources and javadocs can take some time on first use.
@@ -62,6 +62,6 @@ Downloading and resolving the sources and javadocs can take some time on first u
 Fork and clone this repository, (optionally: add awesomeness), and
 then:
 
-```
-sbt publishLocal
+```bash
+> sbt publishLocal
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -34,11 +34,15 @@ licenses := Seq("BSD 3 Clause" -> url("http://opensource.org/licenses/BSD-3-Clau
 
 homepage := Some(url("http://github.com/ensime/ensime-server"))
 
-publishTo <<= version { v: String =>
+publishTo := {
   val nexus = "https://oss.sonatype.org/"
-  if (v.contains("SNAP")) Some("snapshots" at nexus + "content/repositories/snapshots")
-  else                    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+  if (isSnapshot.value)
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
 }
+
+publishMavenStyle := false
 
 credentials += Credentials(
   "Sonatype Nexus Repository Manager", "oss.sonatype.org",

--- a/src/main/scala/CommandSupport.scala
+++ b/src/main/scala/CommandSupport.scala
@@ -1,8 +1,10 @@
+package org.ensime
+
 import sbt._
 import IO._
 
 trait CommandSupport {
-  this: Plugin =>
+  this: AutoPlugin =>
 
   protected def fail(errorMessage: String)(implicit state: State): Nothing = {
     state.log.error(errorMessage)

--- a/src/main/scala/EnsimeConfig.scala
+++ b/src/main/scala/EnsimeConfig.scala
@@ -1,3 +1,5 @@
+package org.ensime
+
 import sbt._
 import scalariform.formatter.preferences.IFormattingPreferences
 

--- a/src/main/scala/EnsimePlugin.scala
+++ b/src/main/scala/EnsimePlugin.scala
@@ -1,3 +1,5 @@
+package org.ensime
+
 import sbt._
 import Keys._
 import IO._
@@ -9,20 +11,39 @@ import SExpFormatter._
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import scalariform.formatter.preferences.IFormattingPreferences
 
-object EnsimePlugin extends Plugin with CommandSupport {
-
-  lazy val ensimeCommand = Command.command("gen-ensime")(genEnsime)
-  override lazy val settings = Seq(
-    commands += ensimeCommand,
-    EnsimeKeys.compilerArgs := (scalacOptions in Compile).value,
-    EnsimeKeys.additionalSExp := ""
-  )
-
+/** Conventional way to define importable keys for an AutoPlugin.
+  * Note that EnsimePlugin.autoImport == Imports
+  */
+object Imports {
   object EnsimeKeys {
     val name = SettingKey[String]("name of the ENSIME project")
     val compilerArgs = TaskKey[Seq[String]]("arguments for the presentation compiler")
     val additionalSExp = TaskKey[String]("raw SExp to include in the output")
   }
+}
+
+object EnsimePlugin extends AutoPlugin with CommandSupport {
+
+  val autoImport = Imports
+
+  // Ensures the underlying base SBT plugin settings are loaded prior to Ensime.
+  // This is important otherwise the `compilerArgs` would not be able to
+  // depend on `scalacOptions in Compile` (becuase they wouldn't be set yet)
+  override def requires = plugins.JvmPlugin
+
+  // Automatically enable the plugin so the user doesn't have to `enablePlugins`
+  // in their projects' build.sbt
+  override def trigger = allRequirements
+
+  import autoImport._
+
+  lazy val ensimeCommand = Command.command("gen-ensime")(genEnsime)
+
+  override lazy val projectSettings = Seq(
+    commands += ensimeCommand,
+    EnsimeKeys.compilerArgs := (scalacOptions in Compile).value,
+    EnsimeKeys.additionalSExp := ""
+  )
 
   def genEnsime(state: State): State = {
     implicit val s = state

--- a/src/main/scala/SExpWriter.scala
+++ b/src/main/scala/SExpWriter.scala
@@ -1,3 +1,5 @@
+package org.ensime
+
 import sbt._
 import scalariform.formatter.preferences._
 


### PR DESCRIPTION
Resolves https://github.com/ensime/ensime-sbt/issues/53

This PR migrates ensime to the new [`AutoPlugin`](http://www.scala-sbt.org/release/docs/Plugins.html#Creating+an+auto+plugin) format.

Other changes included in this PR:
- Updated README with new installation instructions and SBT 0.13.5 requirement
- Updated README with real example for `EnsimeKeys.additionalSExp`
- Re-introduce package org.ensime to avoid potential AutoPlugin clashes
- Use conventional Import object for autoImport
- Clean up build.sbt with `publishMavenStyle := false` and use `isSnapshot.value` instead of checking version string.
