### PR TITLE
Add support for sbt integration tests

### DIFF
--- a/src/main/scala/EnsimeConfig.scala
+++ b/src/main/scala/EnsimeConfig.scala
@@ -22,7 +22,7 @@ case class EnsimeModule(
     mainRoots: Set[File],
     testRoots: Set[File],
     target: File,
-    testTarget: File,
+    testTargets: Set[File],
     dependsOnNames: Set[String],
     compileJars: Set[File],
     runtimeJars: Set[File],

--- a/src/main/scala/SExpWriter.scala
+++ b/src/main/scala/SExpWriter.scala
@@ -65,7 +65,7 @@ object SExpFormatter {
    :module-name ${toSExp(m.name)}
    :source-roots ${fsToSExp((m.mainRoots ++ m.testRoots))}
    :target ${toSExp(m.target)}
-   :test-target ${toSExp(m.testTarget)}
+   :test-targets ${fsToSExp(m.testTargets)}
    :depends-on-modules ${ssToSExp(m.dependsOnNames)}
    :compile-deps ${fsToSExp(m.compileJars)}
    :runtime-deps ${fsToSExp(m.runtimeJars)}


### PR DESCRIPTION
Support for sbt integration tests as defined [here](http://www.scala-sbt.org/0.13/docs/Testing.html#Integration+Tests).
The basic idea is that the `IntegrationTest` scope trumps the `Test` scope when it exists.
