### PR TITLE
sbt 0.12 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 jdk:
 - openjdk6
 scala:
-- 2.10.4
+- 2.9.2
 after_success:
 - sbt ++$TRAVIS_SCALA_VERSION clean $(if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$JAVA_HOME" == "$(jdk_switcher home openjdk6)" ]]; then echo "publish"; fi)
 env:

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ contributors. This is a fairly small and easy to understand plugin, so
 please consider sending us a Pull Request if you have any feature
 request ideas.
 
+ensime-sbt supports sbt 0.12 and 0.13. Below are installation instructions for 0.12.
+For sbt 0.13, see the master branch: https://github.com/ensime/ensime-sbt/tree/master
+
 ## Installation
 
 ENSIME is effectively using a rolling release strategy until version
 1.0. The latest plugin is available by adding the following
-to your `~/.sbt/0.13/plugins/plugins.sbt`:
-
-Ensime is now an [AutoPlugin](http://www.scala-sbt.org/release/docs/Plugins.html#Creating+an+auto+plugin), which requires SBT 0.13.5+.
+to your `~/.sbt/plugins/plugins.sbt`:
 
 ```scala
 resolvers += Resolver.sonatypeRepo("snapshots")
@@ -25,23 +26,23 @@ We recommend installing the plugin in `~/.sbt` as opposed to
 `project/plugins.sbt` because the decision to use ENSIME is per-user,
 rather than per-project.
 
-
-**BUG IN SBT: see https://github.com/sbt/sbt/issues/1592 if you get any problems about `error: value enablePlugins is not a member of sbt.Project`.**
-
-
 If you want to customise the output, create a file `project/ensime.sbt`
-which is ignored by SCM (or use `~/.sbt/0.13/ensime.sbt`), and customise
+which is ignored by SCM (or use `~/.sbt/ensime.sbt`), and customise
 like so:
 
 ```scala
-import org.ensime.Imports._
+import EnsimePlugin._
+import EnsimeKeys._
 
-EnsimeKeys.compilerArgs in Compile := (scalacOptions in Compile).value ++ Seq("-Ywarn-dead-code", "-Ywarn-shadowing")
+// Set global :name property
+projectName := "my-project"
 
-// custom settings (this is an example of adding scalariform formatting preferences):
+// Customize the :compiler-args property
+compilerArgs in Compile <<= (scalacOptions in Compile) map { (o) => o ++ Seq("-Ywarn-dead-code", "-Ywarn-shadowing") }
+
+// add arbitrary keys/values
 EnsimeKeys.additionalSExp in Compile := (additionalSExp in Compile) := ":custom-key custom-value"
 ```
-
 
 ## Usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,16 +9,13 @@ version := "0.1.5-SNAPSHOT"
 sbtPlugin := true
 
 scalacOptions in Compile ++= Seq(
-  "-encoding", "UTF-8", "-target:jvm-1.6", "-feature", "-deprecation",
-  "-Xfatal-warnings",
-  "-language:postfixOps", "-language:implicitConversions"
-  //"-P:wartremover:only-warn-traverser:org.brianmckenna.wartremover.warts.Unsafe"
-  //"-P:wartremover:traverser:org.brianmckenna.wartremover.warts.Unsafe"
+  "-encoding", "UTF-8", "-target:jvm-1.5",
+  "-Xfatal-warnings"
 )
 
 // we actually depend at runtime on scalariform
 // TODO: when ENSIME itself is ready for a reformat, depend on the recent scalariform
-addSbtPlugin("com.typesafe.sbt" %% "sbt-scalariform" % "1.3.0")
+addSbtPlugin("com.typesafe.sbt" %% "sbt-scalariform" % "1.0.1")
 
 publishMavenStyle := true
 
@@ -26,9 +23,9 @@ licenses := Seq("BSD 3 Clause" -> url("http://opensource.org/licenses/BSD-3-Clau
 
 homepage := Some(url("http://github.com/ensime/ensime-server"))
 
-publishTo := {
+publishTo <<= version { (v: String) =>
   val nexus = "https://oss.sonatype.org/"
-  if (isSnapshot.value)
+  if (v.trim.endsWith("SNAPSHOT"))
     Some("snapshots" at nexus + "content/repositories/snapshots")
   else
     Some("releases"  at nexus + "service/local/staging/deploy/maven2")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.6
+sbt.version=0.12.4
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,7 @@
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "0.99.5.1")
-
 // org.scalariform is old, use com.danieltrinh's version
 // this only affects the formatting of sbt itself
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0" excludeAll ExclusionRule("org.scalariform"))
+addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.0.1" excludeAll ExclusionRule("org.scalariform"))
 
 libraryDependencies += "com.danieltrinh" %% "scalariform" % "0.1.5"

--- a/src/main/scala/CommandSupport.scala
+++ b/src/main/scala/CommandSupport.scala
@@ -1,10 +1,8 @@
-package org.ensime
-
 import sbt._
-import IO._
+import sbt.Load.BuildStructure
 
 trait CommandSupport {
-  this: AutoPlugin =>
+  this: Plugin =>
 
   protected def fail(errorMessage: String)(implicit state: State): Nothing = {
     state.log.error(errorMessage)
@@ -14,16 +12,16 @@ trait CommandSupport {
   protected def log(implicit state: State) = state.log
 
   // our version of http://stackoverflow.com/questions/25246920
-  protected implicit class RichSettingKey[A](key: SettingKey[A]) {
+  implicit def enrichSetting[A](key: SettingKey[A]) = new {
     def gimme(implicit pr: ProjectRef, bs: BuildStructure, s: State): A =
-      gimmeOpt getOrElse { fail(s"Missing setting: ${key.key.label}") }
+      gimmeOpt getOrElse { fail("Missing setting: " + key.key.label) }
     def gimmeOpt(implicit pr: ProjectRef, bs: BuildStructure, s: State): Option[A] =
       key in pr get bs.data
   }
 
-  protected implicit class RichTaskKey[A](key: TaskKey[A]) {
+  implicit def enrichTask[A](key: TaskKey[A]) = new {
     def run(implicit pr: ProjectRef, bs: BuildStructure, s: State): A =
-      runOpt.getOrElse { fail(s"Missing task key: ${key.key.label}") }
+      runOpt.getOrElse { fail("Missing task key: " + key.key.label) }
     def runOpt(implicit pr: ProjectRef, bs: BuildStructure, s: State): Option[A] =
       EvaluateTask(bs, key, s, pr).map(_._2) match {
         case Some(Value(v)) => Some(v)

--- a/src/main/scala/EnsimeConfig.scala
+++ b/src/main/scala/EnsimeConfig.scala
@@ -1,7 +1,6 @@
-package org.ensime
-
 import sbt._
 import scalariform.formatter.preferences.IFormattingPreferences
+import java.io.File
 
 case class EnsimeConfig(
   root: File,

--- a/src/main/scala/SExpWriter.scala
+++ b/src/main/scala/SExpWriter.scala
@@ -1,7 +1,7 @@
-package org.ensime
-
 import sbt._
+
 import scalariform.formatter.preferences._
+import java.io.File
 
 // direct formatter to deal with a small number of domain objects
 // if we had to do this for general objects, it would make sense
@@ -26,10 +26,10 @@ object SExpFormatter {
     else ss.map(toSExp).mkString("(", " ", ")")
 
   def fToSExp(key: String, op: Option[File]): String =
-    op.map { f => s":$key ${toSExp(f)}" }.getOrElse("")
+    op.map { f => ":" + key + " " + toSExp(f) }.getOrElse("")
 
   def sToSExp(key: String, op: Option[String]): String =
-    op.map { f => s":$key ${toSExp(f)}" }.getOrElse("")
+    op.map { f => ":" + key + " " + toSExp(f) }.getOrElse("")
 
   def toSExp(b: Boolean): String = if (b) "t" else "nil"
 
@@ -38,37 +38,39 @@ object SExpFormatter {
     case Some(f) if f.preferencesMap.isEmpty => ""
     case Some(f) => f.preferencesMap.map {
       case (desc, v: Boolean) =>
-        s":${desc.key} ${toSExp(v)}"
+        ":" + desc.key + " " + toSExp(v)
       case (desc, v: Int) =>
-        s":${desc.key} $v"
+        ":" + desc.key + " " + v
     }.mkString(":formatting-prefs (", " ", ")")
   }
 
   // a lot of legacy key names and conventions
-  def toSExp(c: EnsimeConfig): String = s"""(
- :root-dir ${toSExp(c.root)}
- :cache-dir ${toSExp(c.cacheDir)}
- :name "${c.name}"
- ${fToSExp("java-home", c.javaHome)}
- :java-flags ${ssToSExp(c.javaFlags)}
- :reference-source-roots ${fsToSExp(c.javaSrc.toIterable)}
- :scala-version ${toSExp(c.scalaVersion)}
- :compiler-args ${ssToSExp(c.compilerArgs)}
- ${toSExp(c.formatting)}
- :subprojects ${msToSExp(c.modules.values)}
- ${c.raw}
+  def toSExp(c: EnsimeConfig): String = {
+"""(
+ :root-dir """ + toSExp(c.root) + """
+ :cache-dir """ + toSExp(c.cacheDir) + """
+ :name """" + c.name + """"
+ """ + fToSExp("java-home", c.javaHome) + """
+ :java-flags """ + ssToSExp(c.javaFlags) + """
+ :reference-source-roots """ + fsToSExp(c.javaSrc.toIterable) + """
+ :scala-version """ + toSExp(c.scalaVersion) + """
+ :compiler-args """ + ssToSExp(c.compilerArgs) + """
+ """ + toSExp(c.formatting) + """
+ :subprojects """ + msToSExp(c.modules.values) + """
+ """ + c.raw + """
 )"""
+  }
 
   // a lot of legacy key names and conventions
-  def toSExp(m: EnsimeModule): String = s"""(
-   :name ${toSExp(m.name)}
-   :module-name ${toSExp(m.name)}
-   :source-roots ${fsToSExp((m.mainRoots ++ m.testRoots))}
-   :target ${toSExp(m.target)}
-   :test-target ${toSExp(m.testTarget)}
-   :depends-on-modules ${ssToSExp(m.dependsOnNames)}
-   :compile-deps ${fsToSExp(m.compileJars)}
-   :runtime-deps ${fsToSExp(m.runtimeJars ++ m.compileJars)}
-   :test-deps ${fsToSExp(m.testJars)}
-   :reference-source-roots ${fsToSExp(m.sourceJars)})"""
+  def toSExp(m: EnsimeModule): String = """(
+   :name """ + toSExp(m.name) + """
+   :module-name """ + toSExp(m.name) + """
+   :source-roots """ + fsToSExp((m.mainRoots ++ m.testRoots)) + """
+   :target """ + toSExp(m.target) + """
+   :test-target """ + toSExp(m.testTarget) + """
+   :depends-on-modules """ + ssToSExp(m.dependsOnNames) + """
+   :compile-deps """ + fsToSExp(m.compileJars) + """
+   :runtime-deps """ + fsToSExp(m.runtimeJars ++ m.compileJars) + """
+   :test-deps """ + fsToSExp(m.testJars) + """
+   :reference-source-roots """ + fsToSExp(m.sourceJars) + """)"""
 }


### PR DESCRIPTION
Fix #65 . This wasn't bad. It mostly undoes the move to "AutoPlugin" and makes the source compile under scala 2.9.

I'm not sure if I got the .travis.yml right.
