### PR TITLE
Included unmanaged jars in dependencies.

### DIFF
--- a/src/main/scala/EnsimePlugin.scala
+++ b/src/main/scala/EnsimePlugin.scala
@@ -136,6 +136,8 @@ object EnsimePlugin extends AutoPlugin with CommandSupport {
       configuration = configurationFilter(filter | config.name.toLowerCase),
       artifact = artifactFilter(extension = "jar")
     ).toSet
+    def unmanagedJarsFor(config: Configuration) =
+      (unmanagedJars in config).run.map(_.data).toSet
     def jarSrcsFor(config: Configuration) = updateClassifiersReport.select(
       configuration = configurationFilter(filter | config.name.toLowerCase),
       artifact = artifactFilter(classifier = "sources")
@@ -150,9 +152,9 @@ object EnsimePlugin extends AutoPlugin with CommandSupport {
     val mainTarget = targetFor(Compile)
     val testTarget = targetFor(Test)
     val deps = project.dependencies.map(_.project.project).toSet
-    val mainJars = jarsFor(Compile)
-    val runtimeJars = jarsFor(Runtime) -- mainJars
-    val testJars = jarsFor(Test) -- mainJars
+    val mainJars = jarsFor(Compile) ++ unmanagedJarsFor(Compile)
+    val runtimeJars = jarsFor(Runtime) ++ unmanagedJarsFor(Runtime) -- mainJars
+    val testJars = jarsFor(Test) ++ unmanagedJarsFor(Test) -- mainJars
     val jarSrcs = jarSrcsFor(Test)
     val jarDocs = jarDocsFor(Test)
 


### PR DESCRIPTION
Unmanaged jars were not included in .ensime file.  For example, say you have lib/fubar.jar and lib/rabuf.jar in a directory off the project root directory and then add the following to build.sbt. The fubar.jar and rabuf.jar files will be included in the build dependencies but they were not included in the .ensime file. This caused errors in ENSIME with unknown symbols and other odd behavior.

``` scala
  unmanagedBase := baseDirectory.value / "lib"

  unmanagedJars in Compile := (unmanagedBase.value ** "*.jar").classpath
```

This may address #66.
