### PR TITLE
Add optional dependencies to main jars and sources.

### DIFF
--- a/src/main/scala/EnsimePlugin.scala
+++ b/src/main/scala/EnsimePlugin.scala
@@ -165,12 +165,13 @@ object EnsimePlugin extends AutoPlugin with CommandSupport {
       artifact = artifactFilter(classifier = "javadoc")
     )).toSet
 
-    val mainSources = sourcesFor(Compile)
+    val mainSources = sourcesFor(Compile) ++ sourcesFor(Provided) ++ sourcesFor(Optional)
     val testSources = sourcesFor(Test) ++ sourcesFor(IntegrationTest)
     val mainTarget = targetFor(Compile)
     val testTargets = (targetForOpt(Test) ++ targetForOpt(IntegrationTest)).toSet
     val deps = project.dependencies.map(_.project.project).toSet
-    val mainJars = jarsFor(Compile) ++ unmanagedJarsFor(Compile) ++ jarsFor(Provided)
+    val mainJars = jarsFor(Compile) ++ unmanagedJarsFor(Compile) ++ jarsFor(Provided) ++
+      jarsFor(Optional)
     val runtimeJars = jarsFor(Runtime) ++ unmanagedJarsFor(Runtime) -- mainJars
     val testJars = jarsFor(Test) ++ jarsFor(IntegrationTest) ++
       unmanagedJarsFor(Test) ++ unmanagedJarsFor(IntegrationTest) -- mainJars


### PR DESCRIPTION
This should resolve [#935](https://github.com/ensime/ensime-server/issues/935).

I added the optional jars to main sources as well, along with the provided jars which looked like an oversight to me. I'm unsure as the difference to managed vs unmanaged jars and whether or not I should be concerned about those jars being included as well.

I tested generating a config with and without this change and verified it fix the issue of an optional dependency not appearing in the jar list.