### PR TITLE
Update README.md with autoplugin sbt.version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ You are also recommended to add the following to your `~/.sbt/0.13/global.sbt` (
 cancelable in Global := true
 ```
 
+Please note your projects' `project/build.properties` need to use a version newer that 0.13.5 of sbt due to a [breaking AutoPlugin change](https://github.com/ensime/ensime-server/issues/672).
+
+```
+sbt.version=0.13.8
+```
+
 ## Commands
 
 * `gen-ensime` --- Generate a `.ensime` for the project.


### PR DESCRIPTION
I noticed the README.md has previously mentioned that the plugin is now an autoplugin and require sbt 0.13.5+ but it seems to have been removed. This burns me every time I set up ensime, though I should probably work on projects that is more up to date... 

This PR adds a few lines to explain how to bump your project's sbt version.