### PR TITLE
Priorities java.home over /usr/libexec/java_home

### DIFF
--- a/src/main/scala/EnsimePlugin.scala
+++ b/src/main/scala/EnsimePlugin.scala
@@ -498,11 +498,11 @@ object EnsimePlugin extends AutoPlugin with CommandSupport {
     // manual
     sys.env.get("JDK_HOME"),
     sys.env.get("JAVA_HOME"),
-    // osx
-    Try("/usr/libexec/java_home".!!.trim).toOption,
     // fallback
     sys.props.get("java.home").map(new File(_).getParent),
-    sys.props.get("java.home")
+    sys.props.get("java.home"),
+    // osx
+    Try("/usr/libexec/java_home".!!.trim).toOption
   ).flatten.filter { n =>
       new File(n + "/lib/tools.jar").exists
     }.headOption.map(new File(_)).getOrElse(


### PR DESCRIPTION
This change only influences systems which have a /usr/libexec/java_home
- namely Mac OS X systems.

Unless the user has specifically set a JDK_HOME or JAVA_HOME, then the
next fallback should be to match the running JVM, by using its java.home
system property, before going for broke and reaching for
/usr/libexec/java_home.

This change enables jenv to do the right thing, which is to configure
which java version to use by using exclusively PATH (using its shims).