### PR TITLE
Bump to coursier 1.0.0-M15 with Java 6 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,8 @@ scalacOptions -= "-Xfatal-warnings"
 libraryDependencies += "org.scalariform" %% "scalariform" % "0.1.4"
 
 libraryDependencies ++= Seq(
-  "io.get-coursier" %% "coursier-java-6" % "1.0.0-M12-1",
-  "io.get-coursier" %% "coursier-cache-java-6" % "1.0.0-M12-1"
+  "io.get-coursier" %% "coursier" % "1.0.0-M15",
+  "io.get-coursier" %% "coursier-cache" % "1.0.0-M15"
 )
 
 scriptedSettings


### PR DESCRIPTION
As of @fommil's refactoring, `ensime-sbt` depends on `coursier`. Because the `ensime`maintainers want to continue supporting Java 6, the dependency was on a special Java 6 compatible build of `coursier`, `coursier-java-6`. Unfortunately, this broke projects that already had a dependency on a normal version of `coursier` (usually via `sbt-coursier`). Luckily, the normal version of the latest release of `coursier`, `1.0.0-M15`, is compatible with Java 6, so we can make everybody happy by updating to it.