### PR TITLE
use stable jars by default

### DIFF
--- a/src/main/scala/EnsimePlugin.scala
+++ b/src/main/scala/EnsimePlugin.scala
@@ -148,11 +148,11 @@ object EnsimePlugin extends AutoPlugin {
 
     ensimeServerVersion := {
       CrossVersion.partialVersion(ensimeScalaVersion.value) match {
-        case Some((2, 10)) => "2.0.0-M2" // 2.0 dropped scala 2.10 support
-        case _             => "2.0.0-SNAPSHOT" // 1.0 clients don't support this style of launch, so why not...
+        case Some((2, 10)) => "2.0.0-M4" // 2.0 will maybe drop scala 2.10 support
+        case _             => "2.0.0-M4" // 1.0 clients don't support this style of launch, so why not...
       }
     },
-    ensimeProjectServerVersion := "2.0.0-M2",
+    ensimeProjectServerVersion := "2.0.0-M4",
 
     ensimeIgnoreSourcesInBase := false,
     ensimeIgnoreMissingDirectories := false,


### PR DESCRIPTION
new policy will be to have maven central jars by default in `sbt-ensime` with opt-in for snapshots // @ktonga that ok with you?