### PR TITLE
Let users know that they can set Scala version temporary before running ensimeConfig

### DIFF
--- a/src/main/scala/EnsimePlugin.scala
+++ b/src/main/scala/EnsimePlugin.scala
@@ -489,7 +489,10 @@ object EnsimePlugin extends AutoPlugin {
            |  scalaVersion in ThisBuild := "${scalaVersion.gimme}"
            |in your build.sbt, or override the ENSIME scala version with:
            |  ensimeScalaVersion in ThisBuild := "${scalaVersion.gimme}"
-           |in a ensime.sbt: http://ensime.org/build_tools/sbt/#customise""".stripMargin
+           |in a ensime.sbt: http://ensime.org/build_tools/sbt/#customise or set Scala version
+           |temporary to ${scalaVersion.gimme} before running "ensimeConfig" task, with:
+           |  ;++${scalaVersion.gimme};ensimeConfig
+           |in interactive SBT prompt""".stripMargin
       )
       if (!ensimeIgnoreScalaMismatch.gimme)
         throw new IllegalStateException(


### PR DESCRIPTION
The user will see a warning message when the Ensime and the project Scala versions are not compatible. It recommends to set the `ensimeScalaVersion` in build.sbt if you want to keep the project version different but another quick workaround can be to set the Scala version temporary with `++[scala-version]` before running `ensimeConfig` task. (eg. `sbt ++2.12.2 ensimeConfig`)

The above workaround is added to the corresponding warning message in this PR.