### PR TITLE
Multi-configuration dependencies

### DIFF
--- a/src/sbt-test-0.13/sbt-ensime/inter-tests/ensimeConfig.expect
+++ b/src/sbt-test-0.13/sbt-ensime/inter-tests/ensimeConfig.expect
@@ -90,7 +90,7 @@
  :library-sources nil
  :library-docs nil) (
  :id (:project "server" :config "compile")
- :depends ((:project "core" :config "compile") (:project "core" :config "it") (:project "core" :config "test"))
+ :depends ((:project "core" :config "compile"))
  :sources ("BASE_DIR/server/src/main/java" "BASE_DIR/server/target/scala-2.12/src_managed/main" "BASE_DIR/server/src/main/scala-2.12" "BASE_DIR/server/src/main/scala")
  :targets ("BASE_DIR/server/target/scala-2.12/classes")
  :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
@@ -99,7 +99,7 @@
  :library-sources nil
  :library-docs ("BASE_DIR/server/target/scala-2.12/server_2.12-0.1-SNAPSHOT-javadoc.jar")) (
  :id (:project "server" :config "it")
- :depends ((:project "core" :config "compile") (:project "core" :config "it") (:project "core" :config "test") (:project "server" :config "compile"))
+ :depends ((:project "core" :config "it") (:project "server" :config "compile"))
  :sources ("BASE_DIR/server/src/main/java" "BASE_DIR/server/target/scala-2.12/src_managed/main" "BASE_DIR/server/src/main/scala-2.12" "BASE_DIR/server/src/main/scala")
  :targets ("BASE_DIR/server/target/scala-2.12/classes")
  :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
@@ -108,7 +108,7 @@
  :library-sources nil
  :library-docs nil) (
  :id (:project "server" :config "test")
- :depends ((:project "core" :config "compile") (:project "core" :config "it") (:project "core" :config "test") (:project "server" :config "compile"))
+ :depends ((:project "core" :config "test") (:project "server" :config "compile"))
  :sources ("BASE_DIR/server/src/test/java" "BASE_DIR/server/src/test/scala-2.12" "BASE_DIR/server/src/test/scala" "BASE_DIR/server/target/scala-2.12/src_managed/test")
  :targets ("BASE_DIR/server/target/scala-2.12/test-classes")
  :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")

--- a/src/sbt-test-0.13/sbt-ensime/multi-project-build/build.sbt
+++ b/src/sbt-test-0.13/sbt-ensime/multi-project-build/build.sbt
@@ -7,3 +7,5 @@ lazy val a = project
 lazy val b = project.dependsOn(a)
 
 lazy val c = project.dependsOn(a).dependsOn(b % "test->test")
+
+lazy val d = project.dependsOn(a).dependsOn(b % "compile->compile;test->test")

--- a/src/sbt-test-0.13/sbt-ensime/multi-project-build/ensimeConfig.expect
+++ b/src/sbt-test-0.13/sbt-ensime/multi-project-build/ensimeConfig.expect
@@ -43,6 +43,16 @@
  :test-deps nil
  :doc-jars ("BASE_DIR/c/target/scala-2.12/c_2.12-0.1-SNAPSHOT-javadoc.jar")
  :reference-source-roots nil) (
+ :name "d"
+ :source-roots nil
+ :targets ("BASE_DIR/d/target/scala-2.12/classes")
+ :test-targets ("BASE_DIR/d/target/scala-2.12/test-classes")
+ :depends-on-modules ("a" "b")
+ :compile-deps nil
+ :runtime-deps nil
+ :test-deps nil
+ :doc-jars ("BASE_DIR/d/target/scala-2.12/d_2.12-0.1-SNAPSHOT-javadoc.jar")
+ :reference-source-roots nil) (
  :name "multi-project-build"
  :source-roots nil
  :targets ("BASE_DIR/target/scala-2.12/classes")
@@ -103,6 +113,24 @@
  :depends ((:project "b" :config "test") (:project "c" :config "compile"))
  :sources nil
  :targets ("BASE_DIR/c/target/scala-2.12/test-classes")
+ :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
+ :javac-options nil
+ :library-jars nil
+ :library-sources nil
+ :library-docs nil) (
+ :id (:project "d" :config "compile")
+ :depends ((:project "a" :config "compile") (:project "b" :config "compile"))
+ :sources nil
+ :targets ("BASE_DIR/d/target/scala-2.12/classes")
+ :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
+ :javac-options nil
+ :library-jars nil
+ :library-sources nil
+ :library-docs ("BASE_DIR/d/target/scala-2.12/d_2.12-0.1-SNAPSHOT-javadoc.jar")) (
+ :id (:project "d" :config "test")
+ :depends ((:project "b" :config "test") (:project "d" :config "compile"))
+ :sources nil
+ :targets ("BASE_DIR/d/target/scala-2.12/test-classes")
  :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
  :javac-options nil
  :library-jars nil

--- a/src/sbt-test-0.13/sbt-ensime/multi-project-build/ensimeConfig.expect
+++ b/src/sbt-test-0.13/sbt-ensime/multi-project-build/ensimeConfig.expect
@@ -82,7 +82,7 @@
  :library-sources nil
  :library-docs ("BASE_DIR/b/target/scala-2.12/b_2.12-0.1-SNAPSHOT-javadoc.jar")) (
  :id (:project "b" :config "test")
- :depends ((:project "a" :config "compile") (:project "b" :config "compile"))
+ :depends ((:project "b" :config "compile"))
  :sources nil
  :targets ("BASE_DIR/b/target/scala-2.12/test-classes")
  :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
@@ -91,7 +91,7 @@
  :library-sources nil
  :library-docs nil) (
  :id (:project "c" :config "compile")
- :depends ((:project "a" :config "compile") (:project "b" :config "test"))
+ :depends ((:project "a" :config "compile"))
  :sources nil
  :targets ("BASE_DIR/c/target/scala-2.12/classes")
  :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
@@ -100,7 +100,7 @@
  :library-sources nil
  :library-docs ("BASE_DIR/c/target/scala-2.12/c_2.12-0.1-SNAPSHOT-javadoc.jar")) (
  :id (:project "c" :config "test")
- :depends ((:project "a" :config "compile") (:project "b" :config "test") (:project "c" :config "compile"))
+ :depends ((:project "b" :config "test") (:project "c" :config "compile"))
  :sources nil
  :targets ("BASE_DIR/c/target/scala-2.12/test-classes")
  :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")


### PR DESCRIPTION
Support `dependsOn` in multiple configurations, example 
```
dependsOn(bar % "test->test;compile->compile")
```

Also, fix dependency tests to be consistent with the interpretation from the docs
http://www.scala-sbt.org/1.x/docs/Multi-Project.html

Fix #372 