### PR TITLE
Use ensimeScalaOptions in the :scalac-options for projects

### DIFF
--- a/src/main/scala/EnsimePlugin.scala
+++ b/src/main/scala/EnsimePlugin.scala
@@ -213,10 +213,7 @@ object EnsimePlugin extends AutoPlugin {
     ensimeConfigTransformerProject := identity,
     ensimeUseTarget := None,
 
-    ensimeScalacOptions := (
-      (scalacOptions in Compile).value ++
-      ensimeSuggestedScalacOptions((ensimeScalaVersion in ThisBuild).value)
-    ).distinct,
+    ensimeScalacOptions := Nil,
     ensimeJavacOptions := (javacOptions in Compile).value,
 
     ensimeConfig := ensimeConfigTask.evaluated,
@@ -340,7 +337,9 @@ object EnsimePlugin extends AutoPlugin {
       if (subProjects.size == 1) subProjects.head.id.project
       else root.getAbsoluteFile.getName
     }
-    val compilerArgs = (ensimeScalacOptions).value.toList
+    val compilerArgs = ((scalacOptions in Compile).value ++
+      ensimeSuggestedScalacOptions(ensimeScalaV) ++
+      (ensimeScalacOptions in Compile).value).toList
     val javaCompilerArgs = (ensimeJavacOptions).value.toList
     val javaSrc = {
       file(javaH.getAbsolutePath + "/src.zip") match {
@@ -475,8 +474,8 @@ object EnsimePlugin extends AutoPlugin {
 
       val target = targetForOpt(config).get
       val scalaCompilerArgs = ((scalacOptions in config).run ++
-        (ensimeScalacOptions in config).run ++
-        ensimeSuggestedScalacOptions(ensimeScalaV)).toList.distinct
+        ensimeSuggestedScalacOptions(ensimeScalaV) ++
+        (ensimeScalacOptions in config).run).toList
       val javaCompilerArgs = (javacOptions in config).run.toList
       val jars = config match {
         case Compile => jarsFor(Compile) ++ unmanagedJarsFor(Compile) ++ jarsFor(Provided) ++ jarsFor(Optional)

--- a/src/main/scala/EnsimePlugin.scala
+++ b/src/main/scala/EnsimePlugin.scala
@@ -475,7 +475,8 @@ object EnsimePlugin extends AutoPlugin {
 
       val target = targetForOpt(config).get
       val scalaCompilerArgs = ((scalacOptions in config).run ++
-        ensimeSuggestedScalacOptions(ensimeScalaV)).toList
+        (ensimeScalacOptions in config).run ++
+        ensimeSuggestedScalacOptions(ensimeScalaV)).toList.distinct
       val javaCompilerArgs = (javacOptions in config).run.toList
       val jars = config match {
         case Compile => jarsFor(Compile) ++ unmanagedJarsFor(Compile) ++ jarsFor(Provided) ++ jarsFor(Optional)

--- a/src/sbt-test-0.13/sbt-ensime/different-scalaorganization/ensimeConfig.expect
+++ b/src/sbt-test-0.13/sbt-ensime/different-scalaorganization/ensimeConfig.expect
@@ -28,7 +28,7 @@
  :depends nil
  :sources ("BASE_DIR/src/main/java" "BASE_DIR/target/scala-2.12/src_managed/main" "BASE_DIR/src/main/scala-2.12" "BASE_DIR/src/main/scala")
  :targets ("BASE_DIR/target/scala-2.12/classes")
- :scalac-options ("-Xlog-reflective-calls" "-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
+ :scalac-options ("-Xlog-reflective-calls" "-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard" "-Xplugin:COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/spire-math/kind-projector_2.12/0.9.3/kind-projector_2.12-0.9.3.jar")
  :javac-options nil
  :library-jars ("IVY_DIR/cache/org.typelevel/scala-library/jars/scala-library-2.12.2-bin-typelevel-4.jar")
  :library-sources ("IVY_DIR/cache/org.typelevel/scala-library/srcs/scala-library-2.12.2-bin-typelevel-4-sources.jar")
@@ -37,7 +37,7 @@
  :depends ((:project "different-scalaorganization" :config "compile"))
  :sources ("BASE_DIR/src/test/java" "BASE_DIR/src/test/scala-2.12" "BASE_DIR/src/test/scala" "BASE_DIR/target/scala-2.12/src_managed/test")
  :targets ("BASE_DIR/target/scala-2.12/test-classes")
- :scalac-options ("-Xlog-reflective-calls" "-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
+ :scalac-options ("-Xlog-reflective-calls" "-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard" "-Xplugin:COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/spire-math/kind-projector_2.12/0.9.3/kind-projector_2.12-0.9.3.jar")
  :javac-options nil
  :library-jars nil
  :library-sources nil

--- a/src/sbt-test-0.13/sbt-ensime/scalac-options/build.sbt
+++ b/src/sbt-test-0.13/sbt-ensime/scalac-options/build.sbt
@@ -1,0 +1,11 @@
+scalaVersion in ThisBuild := "2.12.2"
+
+ensimeIgnoreMissingDirectories in ThisBuild := true
+
+ensimeScalacOptions +=  "-wibble"
+
+lazy val a = project.settings(
+  ensimeScalacOptions +=  "-wobble"
+)
+
+ensimeScalacOptions in a in Test +=  "-wriggle"

--- a/src/sbt-test-0.13/sbt-ensime/scalac-options/ensimeConfig.expect
+++ b/src/sbt-test-0.13/sbt-ensime/scalac-options/ensimeConfig.expect
@@ -4,14 +4,14 @@
  :scala-compiler-jars ("COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.2/scala-compiler-2.12.2.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.2/scala-library-2.12.2.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.2/scala-reflect-2.12.2.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/scala-lang/scalap/2.12.2/scalap-2.12.2.jar")
  :ensime-server-jars ("COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/ensime/monkeys_2.12/2.0.0/monkeys_2.12-2.0.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/javax/activation/activation/1.1/activation-1.1.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-actor_2.12/2.5.3/akka-actor_2.12-2.5.3.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-slf4j_2.12/2.5.3/akka-slf4j_2.12-2.5.3.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/ensime/api_2.12/2.0.0/api_2.12-2.0.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/ow2/asm/asm/5.2/asm-5.2.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-commons/5.2/asm-commons-5.2.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-tree/5.2/asm-tree-5.2.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-util/5.2/asm-util-5.2.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/tinkerpop/blueprints/blueprints-core/2.6.0/blueprints-core-2.6.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/commons-beanutils/commons-beanutils-core/1.8.0/commons-beanutils-core-1.8.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/commons-configuration/commons-configuration/1.6/commons-configuration-1.6.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/commons-digester/commons-digester/1.8/commons-digester-1.8.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/commons-lang/commons-lang/2.4/commons-lang-2.4.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/apache/commons/commons-vfs2/2.1/commons-vfs2-2.1.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/googlecode/concurrentlinkedhashmap/concurrentlinkedhashmap-lru/1.4.1/concurrentlinkedhashmap-lru-1.4.1.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/typesafe/config/1.3.1/config-1.3.1.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/ensime/core_2.12/2.0.0/core_2.12-2.0.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/lihaoyi/fastparse-utils_2.12/0.4.3/fastparse-utils_2.12-0.4.3.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/lihaoyi/fastparse_2.12/0.4.3/fastparse_2.12-0.4.3.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/carrotsearch/hppc/0.6.0/hppc-0.6.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.6.0/jackson-annotations-2.6.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.6.0/jackson-core-2.6.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.6.0/jackson-databind-2.6.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/slf4j/jcl-over-slf4j/1.7.25/jcl-over-slf4j-1.7.25.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/ensime/jerky_2.12/2.0.0/jerky_2.12-2.0.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/codehaus/jettison/jettison/1.3.3/jettison-1.3.3.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/ensime/json_2.12/2.0.0/json_2.12-2.0.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/slf4j/jul-to-slf4j/1.7.25/jul-to-slf4j-1.7.25.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/slf4j/log4j-over-slf4j/1.7.25/log4j-over-slf4j-1.7.25.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/apache/lucene/lucene-analyzers-common/6.4.2/lucene-analyzers-common-6.4.2.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/apache/lucene/lucene-core/6.4.2/lucene-core-6.4.2.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/javax/mail/mail/1.4.7/mail-1.4.7.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/io/netty/netty-buffer/4.1.13.Final/netty-buffer-4.1.13.Final.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/io/netty/netty-codec/4.1.13.Final/netty-codec-4.1.13.Final.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.13.Final/netty-codec-http-4.1.13.Final.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/io/netty/netty-common/4.1.13.Final/netty-common-4.1.13.Final.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/io/netty/netty-handler/4.1.13.Final/netty-handler-4.1.13.Final.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/io/netty/netty-resolver/4.1.13.Final/netty-resolver-4.1.13.Final.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/io/netty/netty-transport/4.1.13.Final/netty-transport-4.1.13.Final.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/scala-refactoring/org.scala-refactoring.library_2.12.2/0.13.0/org.scala-refactoring.library_2.12.2-0.13.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/orientechnologies/orientdb-client/2.2.24/orientdb-client-2.2.24.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/orientechnologies/orientdb-core/2.2.24/orientdb-core-2.2.24.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/orientechnologies/orientdb-graphdb/2.2.24/orientdb-graphdb-2.2.24.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/orientechnologies/orientdb-server/2.2.24/orientdb-server-2.2.24.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/orientechnologies/orientdb-tools/2.2.24/orientdb-tools-2.2.24.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/ensime/s-express_2.12/2.0.0/s-express_2.12-2.0.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/scala-debugger/scala-debugger-api_2.12/1.1.0-M3/scala-debugger-api_2.12-1.1.0-M3.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/scala-debugger/scala-debugger-macros_2.12/1.1.0-M3/scala-debugger-macros_2.12-1.1.0-M3.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/ensime/server_2.12/2.0.0/server_2.12-2.0.0.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/xerial/snappy/snappy-java/1.1.0.1/snappy-java-1.1.0.1.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/com/lihaoyi/sourcecode_2.12/0.1.3/sourcecode_2.12-0.1.3.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/stax/stax-api/1.0.1/stax-api-1.0.1.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/ensime/swanky_2.12/2.0.0/swanky_2.12-2.0.0.jar" "JDK_HOME/lib/tools.jar" "COURSIER_DIR/cache/v1/https/repo1.maven.org/maven2/org/ensime/util_2.12/2.0.0/util_2.12-2.0.0.jar")
  :ensime-server-version "2.0.0"
- :name "multi-project-build"
+ :name "scalac-options"
  :java-home "JDK_HOME"
  :java-flags ("-Xss2m" "-Xms512m" "-Xmx4g" "-XX:MaxMetaspaceSize=256m" "-XX:StringTableSize=1000003" "-XX:+UnlockExperimentalVMOptions" "-XX:SymbolTableSize=1000003" "-Dscala.classpath.closeZip=true")
  :java-sources ("JDK_HOME/src.zip")
  :java-compiler-args nil
  :reference-source-roots ("JDK_HOME/src.zip")
  :scala-version "2.12.2"
- :compiler-args ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
+ :compiler-args ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard" "-wibble")
  :subprojects ((
  :name "a"
  :source-roots nil
@@ -23,57 +23,7 @@
  :test-deps nil
  :doc-jars ("BASE_DIR/a/target/scala-2.12/a_2.12-0.1-SNAPSHOT-javadoc.jar" "IVY_DIR/cache/org.scala-lang/scala-library/docs/scala-library-2.12.2-javadoc.jar")
  :reference-source-roots ("IVY_DIR/cache/org.scala-lang/scala-library/srcs/scala-library-2.12.2-sources.jar")) (
- :name "b"
- :source-roots nil
- :targets ("BASE_DIR/b/target/scala-2.12/classes")
- :test-targets ("BASE_DIR/b/target/scala-2.12/test-classes")
- :depends-on-modules ("a")
- :compile-deps nil
- :runtime-deps nil
- :test-deps nil
- :doc-jars ("BASE_DIR/b/target/scala-2.12/b_2.12-0.1-SNAPSHOT-javadoc.jar")
- :reference-source-roots nil) (
- :name "c"
- :source-roots nil
- :targets ("BASE_DIR/c/target/scala-2.12/classes")
- :test-targets ("BASE_DIR/c/target/scala-2.12/test-classes")
- :depends-on-modules ("a" "b")
- :compile-deps nil
- :runtime-deps nil
- :test-deps nil
- :doc-jars ("BASE_DIR/c/target/scala-2.12/c_2.12-0.1-SNAPSHOT-javadoc.jar")
- :reference-source-roots nil) (
- :name "d"
- :source-roots nil
- :targets ("BASE_DIR/d/target/scala-2.12/classes")
- :test-targets ("BASE_DIR/d/target/scala-2.12/test-classes")
- :depends-on-modules ("a" "b")
- :compile-deps nil
- :runtime-deps nil
- :test-deps nil
- :doc-jars ("BASE_DIR/d/target/scala-2.12/d_2.12-0.1-SNAPSHOT-javadoc.jar")
- :reference-source-roots nil) (
- :name "e"
- :source-roots nil
- :targets ("BASE_DIR/e/target/scala-2.12/classes")
- :test-targets ("BASE_DIR/e/target/scala-2.12/test-classes")
- :depends-on-modules ("a" "b")
- :compile-deps nil
- :runtime-deps nil
- :test-deps nil
- :doc-jars ("BASE_DIR/e/target/scala-2.12/e_2.12-0.1-SNAPSHOT-javadoc.jar")
- :reference-source-roots nil) (
- :name "f"
- :source-roots nil
- :targets ("BASE_DIR/f/target/scala-2.12/classes")
- :test-targets ("BASE_DIR/f/target/scala-2.12/classes" "BASE_DIR/f/target/scala-2.12/test-classes")
- :depends-on-modules ("a")
- :compile-deps ("IVY_DIR/cache/org.scala-lang/scala-library/jars/scala-library-2.12.2.jar")
- :runtime-deps nil
- :test-deps nil
- :doc-jars ("BASE_DIR/f/target/scala-2.12/f_2.12-0.1-SNAPSHOT-javadoc.jar" "IVY_DIR/cache/org.scala-lang/scala-library/docs/scala-library-2.12.2-javadoc.jar")
- :reference-source-roots ("IVY_DIR/cache/org.scala-lang/scala-library/srcs/scala-library-2.12.2-sources.jar")) (
- :name "multi-project-build"
+ :name "scalac-options"
  :source-roots nil
  :targets ("BASE_DIR/target/scala-2.12/classes")
  :test-targets ("BASE_DIR/target/scala-2.12/test-classes")
@@ -81,14 +31,14 @@
  :compile-deps ("IVY_DIR/cache/org.scala-lang/scala-library/jars/scala-library-2.12.2.jar")
  :runtime-deps nil
  :test-deps nil
- :doc-jars ("BASE_DIR/target/scala-2.12/multi-project-build_2.12-0.1-SNAPSHOT-javadoc.jar" "IVY_DIR/cache/org.scala-lang/scala-library/docs/scala-library-2.12.2-javadoc.jar")
+ :doc-jars ("IVY_DIR/cache/org.scala-lang/scala-library/docs/scala-library-2.12.2-javadoc.jar" "BASE_DIR/target/scala-2.12/scalac-options_2.12-0.1-SNAPSHOT-javadoc.jar")
  :reference-source-roots ("IVY_DIR/cache/org.scala-lang/scala-library/srcs/scala-library-2.12.2-sources.jar")))
  :projects ((
  :id (:project "a" :config "compile")
  :depends nil
  :sources nil
  :targets ("BASE_DIR/a/target/scala-2.12/classes")
- :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
+ :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard" "-wobble")
  :javac-options nil
  :library-jars ("IVY_DIR/cache/org.scala-lang/scala-library/jars/scala-library-2.12.2.jar")
  :library-sources ("IVY_DIR/cache/org.scala-lang/scala-library/srcs/scala-library-2.12.2-sources.jar")
@@ -97,124 +47,25 @@
  :depends ((:project "a" :config "compile"))
  :sources nil
  :targets ("BASE_DIR/a/target/scala-2.12/test-classes")
- :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
+ :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard" "-wobble" "-wriggle")
  :javac-options nil
  :library-jars nil
  :library-sources nil
  :library-docs nil) (
- :id (:project "b" :config "compile")
- :depends ((:project "a" :config "compile"))
- :sources nil
- :targets ("BASE_DIR/b/target/scala-2.12/classes")
- :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
- :javac-options nil
- :library-jars nil
- :library-sources nil
- :library-docs ("BASE_DIR/b/target/scala-2.12/b_2.12-0.1-SNAPSHOT-javadoc.jar")) (
- :id (:project "b" :config "test")
- :depends ((:project "b" :config "compile"))
- :sources nil
- :targets ("BASE_DIR/b/target/scala-2.12/test-classes")
- :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
- :javac-options nil
- :library-jars nil
- :library-sources nil
- :library-docs nil) (
- :id (:project "c" :config "compile")
- :depends ((:project "a" :config "compile"))
- :sources nil
- :targets ("BASE_DIR/c/target/scala-2.12/classes")
- :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
- :javac-options nil
- :library-jars nil
- :library-sources nil
- :library-docs ("BASE_DIR/c/target/scala-2.12/c_2.12-0.1-SNAPSHOT-javadoc.jar")) (
- :id (:project "c" :config "test")
- :depends ((:project "b" :config "test") (:project "c" :config "compile"))
- :sources nil
- :targets ("BASE_DIR/c/target/scala-2.12/test-classes")
- :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
- :javac-options nil
- :library-jars nil
- :library-sources nil
- :library-docs nil) (
- :id (:project "d" :config "compile")
- :depends ((:project "a" :config "compile") (:project "b" :config "compile"))
- :sources nil
- :targets ("BASE_DIR/d/target/scala-2.12/classes")
- :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
- :javac-options nil
- :library-jars nil
- :library-sources nil
- :library-docs ("BASE_DIR/d/target/scala-2.12/d_2.12-0.1-SNAPSHOT-javadoc.jar")) (
- :id (:project "d" :config "test")
- :depends ((:project "b" :config "test") (:project "d" :config "compile"))
- :sources nil
- :targets ("BASE_DIR/d/target/scala-2.12/test-classes")
- :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
- :javac-options nil
- :library-jars nil
- :library-sources nil
- :library-docs nil) (
- :id (:project "e" :config "compile")
- :depends ((:project "a" :config "compile"))
- :sources nil
- :targets ("BASE_DIR/e/target/scala-2.12/classes")
- :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
- :javac-options nil
- :library-jars nil
- :library-sources nil
- :library-docs ("BASE_DIR/e/target/scala-2.12/e_2.12-0.1-SNAPSHOT-javadoc.jar")) (
- :id (:project "e" :config "test")
- :depends ((:project "b" :config "compile") (:project "e" :config "compile"))
- :sources nil
- :targets ("BASE_DIR/e/target/scala-2.12/test-classes")
- :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
- :javac-options nil
- :library-jars nil
- :library-sources nil
- :library-docs nil) (
- :id (:project "f" :config "compile")
- :depends nil
- :sources nil
- :targets ("BASE_DIR/f/target/scala-2.12/classes")
- :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
- :javac-options nil
- :library-jars ("IVY_DIR/cache/org.scala-lang/scala-library/jars/scala-library-2.12.2.jar")
- :library-sources ("IVY_DIR/cache/org.scala-lang/scala-library/srcs/scala-library-2.12.2-sources.jar")
- :library-docs ("BASE_DIR/f/target/scala-2.12/f_2.12-0.1-SNAPSHOT-javadoc.jar" "IVY_DIR/cache/org.scala-lang/scala-library/docs/scala-library-2.12.2-javadoc.jar")) (
- :id (:project "f" :config "it")
- :depends ((:project "a" :config "compile") (:project "f" :config "compile"))
- :sources nil
- :targets ("BASE_DIR/f/target/scala-2.12/classes")
- :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
- :javac-options nil
- :library-jars nil
- :library-sources nil
- :library-docs nil) (
- :id (:project "f" :config "test")
- :depends ((:project "a" :config "compile") (:project "f" :config "compile"))
- :sources nil
- :targets ("BASE_DIR/f/target/scala-2.12/test-classes")
- :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
- :javac-options nil
- :library-jars nil
- :library-sources nil
- :library-docs nil) (
- :id (:project "multi-project-build" :config "compile")
+ :id (:project "scalac-options" :config "compile")
  :depends nil
  :sources nil
  :targets ("BASE_DIR/target/scala-2.12/classes")
- :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
+ :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard" "-wibble")
  :javac-options nil
  :library-jars ("IVY_DIR/cache/org.scala-lang/scala-library/jars/scala-library-2.12.2.jar")
  :library-sources ("IVY_DIR/cache/org.scala-lang/scala-library/srcs/scala-library-2.12.2-sources.jar")
- :library-docs ("BASE_DIR/target/scala-2.12/multi-project-build_2.12-0.1-SNAPSHOT-javadoc.jar" "IVY_DIR/cache/org.scala-lang/scala-library/docs/scala-library-2.12.2-javadoc.jar")) (
- :id (:project "multi-project-build" :config "test")
- :depends ((:project "multi-project-build" :config "compile"))
+ :library-docs ("IVY_DIR/cache/org.scala-lang/scala-library/docs/scala-library-2.12.2-javadoc.jar" "BASE_DIR/target/scala-2.12/scalac-options_2.12-0.1-SNAPSHOT-javadoc.jar")) (
+ :id (:project "scalac-options" :config "test")
+ :depends ((:project "scalac-options" :config "compile"))
  :sources nil
  :targets ("BASE_DIR/target/scala-2.12/test-classes")
- :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard")
+ :scalac-options ("-feature" "-deprecation" "-Xlint" "-Ywarn-dead-code" "-Ywarn-numeric-widen" "-Xfuture" "-Ymacro-expand:discard" "-wibble")
  :javac-options nil
  :library-jars nil
  :library-sources nil

--- a/src/sbt-test-0.13/sbt-ensime/scalac-options/project/EnsimeSbtTestSupport.scala
+++ b/src/sbt-test-0.13/sbt-ensime/scalac-options/project/EnsimeSbtTestSupport.scala
@@ -1,0 +1,1 @@
+../../inter-tests/project/EnsimeSbtTestSupport.scala

--- a/src/sbt-test-0.13/sbt-ensime/scalac-options/project/plugins.sbt
+++ b/src/sbt-test-0.13/sbt-ensime/scalac-options/project/plugins.sbt
@@ -1,0 +1,1 @@
+../../simple-build-sbt/project/plugins.sbt

--- a/src/sbt-test-0.13/sbt-ensime/scalac-options/project/testing.sbt
+++ b/src/sbt-test-0.13/sbt-ensime/scalac-options/project/testing.sbt
@@ -1,0 +1,1 @@
+../../inter-tests/project/testing.sbt

--- a/src/sbt-test-0.13/sbt-ensime/scalac-options/test
+++ b/src/sbt-test-0.13/sbt-ensime/scalac-options/test
@@ -1,0 +1,2 @@
+> ensimeConfig
+> ensimeExpect .ensime ensimeConfig.expect

--- a/src/sbt-test-1.0/sbt-ensime/scalac-options
+++ b/src/sbt-test-1.0/sbt-ensime/scalac-options
@@ -1,0 +1,1 @@
+../../sbt-test-0.13/sbt-ensime/scalac-options


### PR DESCRIPTION
Resolve #376 

`ensimeScalacOptions` can now be customized to add scalac flags for the ensime analyzer. 

To add a setting for all configurations in a projects it need to be part of the settings.
```scala
lazy val a = project.settings(
  ensimeScalacOptions +=  "-wobble"
)
```

Or it can be added in a configuration like 

```scala
ensimeScalacOptions in a in Test += "-wibble"
```

Close #375 in favor of this.