### PR TITLE
restore snapshots repo url at ensimeRepositoryUrls from EnsimeCoursierPlugin

### DIFF
--- a/src/main/scala/EnsimeCoursierPlugin.scala
+++ b/src/main/scala/EnsimeCoursierPlugin.scala
@@ -42,7 +42,9 @@ object EnsimeCoursierPlugin extends AutoPlugin {
   override lazy val buildSettings = Seq(
     ensimeRepositoryUrls := Seq(
       // intentionally not using the ivy cache because it's very unreliable
-      "https://repo1.maven.org/maven2/"
+      "https://repo1.maven.org/maven2/",
+      // including snapshots by default makes it easier to use dev ensime
+      "https://oss.sonatype.org/content/repositories/snapshots/"
     ),
 
     ensimeScalaJars := resolveScalaJars(scalaOrganization.value, ensimeScalaVersion.value, ensimeRepositoryUrls.value),


### PR DESCRIPTION
I found that trick for `ensimeRepositoryUrls` which described at https://github.com/ensime/ensime.github.io/blob/master/build_tools/sbt.md#unstable-server
doesn't works. Even if EnsimeCoursierKeys import added:
```scala
import org.ensime.EnsimeCoursierKeys._
import org.ensime.EnsimeKeys._

ensimeRepositoryUrls += "https://oss.sonatype.org/content/repositories/snapshots/"
ensimeServerVersion in ThisBuild := "3.0.0-SNAPSHOT"
ensimeProjectServerVersion in ThisBuild := "3.0.0-SNAPSHOT"
```
error:
```
[error] ({.}/*:ensimeServerJars) failed to resolve ((org.ensime:server_2.12,3.0.0-SNAPSHOT),List(not found: https://repo1.maven.org/maven2/org/ensime/server_2.12/3.0.0-SNAPSHOT/server_2.12-3.0.0-SNAPSHOT.pom))
```

It seems like `ensimeRepositoryUrls` at `EnsimeCoursierPlugin` always overriding value from `~/.sbt/0.13/global.sbt`. Because of I proposing to put back default snapshots repo link to ensimeRepositoryUrls,  but I don't know story behind removing it originally. 
Maybe, Is it exist another workaround for this?
