### PR TITLE
bump the server version, don't filter paradise by default

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.1.2

--- a/src/main/scala/EnsimePlugin.scala
+++ b/src/main/scala/EnsimePlugin.scala
@@ -173,11 +173,11 @@ object EnsimePlugin extends AutoPlugin {
 
     ensimeServerVersion := {
       CrossVersion.partialVersion(ensimeScalaVersion.value) match {
-        case Some((2, 10)) => "2.0.0" // 3.0 drops scala 2.10 support
-        case _             => "2.0.0"
+        case Some((2, 10)) => "2.0.1" // 3.0 drops scala 2.10 support
+        case _             => "2.0.1"
       }
     },
-    ensimeProjectServerVersion := "2.0.0", // should really filter on sbtVersion
+    ensimeProjectServerVersion := "2.0.1", // should really filter on sbtVersion
 
     ensimeIgnoreSourcesInBase := false,
     ensimeIgnoreMissingDirectories := false,
@@ -242,8 +242,7 @@ object EnsimePlugin extends AutoPlugin {
     ensimeUseTarget := None,
 
     // I can't get dynamic tasks to work, so this is the hack...
-    // macro-paradise and meta-paradise are fundamentally broken in the PC.
-    ensimeScalacTransformer := (opts => opts.filterNot(_.contains("paradise"))),
+    ensimeScalacTransformer := identity,
     ensimeScalacOptions := ensimeSuggestedScalacOptions(scalaVersion.value),
     ensimeJavacOptions := Nil,
 

--- a/src/sbt-test-0.13/sbt-ensime/scalac-options/build.sbt
+++ b/src/sbt-test-0.13/sbt-ensime/scalac-options/build.sbt
@@ -7,7 +7,8 @@ ensimeScalacOptions +=  "-wibble"
 lazy val a = project.settings(
   ensimeScalacOptions += "-wobble",
   addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6"),
-  addCompilerPlugin(("org.scalamacros" % "paradise" % "2.1.1").cross(CrossVersion.full))
+  addCompilerPlugin(("org.scalamacros" % "paradise" % "2.1.1").cross(CrossVersion.full)),
+  ensimeScalacTransformer := (opts => opts.filterNot(_.contains("paradise")))
 )
 
 ensimeScalacOptions in a in Test +=  "-wriggle"


### PR DESCRIPTION
@vil1 filtering macro-paradise was causing more harm than good, so it's going back in for 2.5.1.