### PR TITLE
[fix] ivy config regex allowed white space

### DIFF
--- a/src/main/scala/EnsimePlugin.scala
+++ b/src/main/scala/EnsimePlugin.scala
@@ -491,7 +491,7 @@ object EnsimePlugin extends AutoPlugin {
       artifact = artifactFilter(classifier = Artifact.DocClassifier)
     ).toSet ++ (ensimeUnmanagedJavadocArchives in config in projectRef).run
 
-    val IvyConfig = "([A-Za-z]+)->([A-Za-z]+)".r
+    val IvyConfig = """\s*([A-Za-z]+)\s*->\s*([A-Za-z]+)\s*""".r
 
     def depsFor(config: Configuration): Seq[EnsimeProjectId] = project.dependencies.flatMap { d =>
       lazy val name = d.project.project


### PR DESCRIPTION
`sbt` allowed to `"compile -> compile; test -> test"` . in "Classpath dependencies" string. (the arrow between the width space)
```scala
lazy val mainProject = (project in file("."))
  .dependsOn(subProject % "compile -> compile; test -> test")
```
but `ensime-sbt` plugin not allowed width space.
I want to reduce the people who stumble in a small reason.
